### PR TITLE
Refactor IcebergConnector and update dependencies

### DIFF
--- a/connectors/lakehouse/iceberg/pom.xml
+++ b/connectors/lakehouse/iceberg/pom.xml
@@ -38,18 +38,29 @@
             <version>${iceberg.version}</version>
         </dependency>
         
-        <!-- Apache Iceberg Hadoop Runtime -->
+        <!-- Apache Parquet Common (required for Parquet schema MessageType) -->
         <dependency>
-            <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-hadoop-runtime</artifactId>
-            <version>${iceberg.version}</version>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-common</artifactId>
+            <version>1.13.1</version>
         </dependency>
         
-        <!-- Hadoop Common (required for Iceberg) -->
+        <!-- Hadoop Common (required for HadoopCatalog) -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+                <!-- Exclude conflicting logging dependencies -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         
         <!-- Jackson for JSON parsing -->
@@ -83,5 +94,3 @@
     </build>
 
 </project>
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,6 @@
     <module>spi</module>
     <module>server</module>
     <module>connectors</module>
-    <module>connectors/kafka</module>
-    <module>connectors/console</module>
-    <module>connectors/pubsub</module>
-      <module>connectors/logger</module>
   </modules>
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>


### PR DESCRIPTION
Removed unused modules from the root pom.xml and updated the Iceberg connector's pom.xml to add Parquet dependency and exclude conflicting logging dependencies. Refactored IcebergConnector to use field IDs for record setting, removed unnecessary table closing, and simplified field creation logic for better compatibility with Iceberg APIs.